### PR TITLE
Don't capitalize the author name

### DIFF
--- a/src/nimeventer/nimforum.nim
+++ b/src/nimeventer/nimforum.nim
@@ -121,7 +121,7 @@ proc checkNimforum(c: Config) {.async.} =
   let threadAuthor = newThread.author.capitalizeAscii()
   let threadLink = fmt"{c.baseUrl}t/{newThread.id}"
   let postLink = fmt"{c.baseUrl}t/{newThread.id}#{newPost.id}"
-  let postAuthor = newPost.author.capitalizeAscii()
+  let postAuthor = newPost.author
   let postContext = newPost.startContext
   
   # We already know about that post (or thread)

--- a/src/nimeventer/nimforum.nim
+++ b/src/nimeventer/nimforum.nim
@@ -118,7 +118,7 @@ proc checkNimforum(c: Config) {.async.} =
   kdb["forumLastActivity"] = $newPost.created
 
   let threadTitle = newThread.title.capitalizeAscii()
-  let threadAuthor = newThread.author.capitalizeAscii()
+  let threadAuthor = newThread.author
   let threadLink = fmt"{c.baseUrl}t/{newThread.id}"
   let postLink = fmt"{c.baseUrl}t/{newThread.id}#{newPost.id}"
   let postAuthor = newPost.author


### PR DESCRIPTION
Imo it makes more sense to print the actual author name, without first capitalizing it. Most names are already capitalized anyway and when they aren't, it's usually intentional.